### PR TITLE
Update AD936x filter support on sinks

### DIFF
--- a/gr-iio/lib/device_source_impl.cc
+++ b/gr-iio/lib/device_source_impl.cc
@@ -375,7 +375,8 @@ int device_source_impl::handle_decimation_interpolation(unsigned long samplerate
                                                         const char* channel_name,
                                                         const char* attr_name,
                                                         struct iio_device* dev,
-                                                        bool disable_dec)
+                                                        bool disable_dec,
+                                                        bool output_chan)
 {
     int ret;
     struct iio_channel* chan;
@@ -386,7 +387,7 @@ int device_source_impl::handle_decimation_interpolation(unsigned long samplerate
     an.append("_available");
 
     // Get ranges
-    chan = iio_device_find_channel(dev, channel_name, false);
+    chan = iio_device_find_channel(dev, channel_name, output_chan);
     if (chan == NULL)
         return -1; // Channel doesn't exist so the dec/int filters probably don't exist
 

--- a/gr-iio/lib/device_source_impl.h
+++ b/gr-iio/lib/device_source_impl.h
@@ -93,11 +93,12 @@ public:
 
     static struct iio_context* get_context(const std::string& uri);
     static bool load_fir_filter(std::string& filter, struct iio_device* phy);
-    int handle_decimation_interpolation(unsigned long samplerate,
+    static int handle_decimation_interpolation(unsigned long samplerate,
                                         const char* channel_name,
                                         const char* attr_name,
                                         struct iio_device* dev,
-                                        bool disable_dec);
+                                        bool disable_dec,
+                                        bool output_chan);
 };
 
 } // namespace iio

--- a/gr-iio/lib/fmcomms2_source_impl.cc
+++ b/gr-iio/lib/fmcomms2_source_impl.cc
@@ -207,13 +207,13 @@ void fmcomms2_source_impl::set_samplerate(unsigned long samplerate)
         int ret;
         samplerate = samplerate * DECINT_RATIO;
         ret = device_source_impl::handle_decimation_interpolation(
-            samplerate, "voltage0", "sampling_frequency", dev, false);
+            samplerate, "voltage0", "sampling_frequency", dev, false, false);
         if (ret < 0)
             samplerate = samplerate / 8;
     } else // Disable decimation filter if on
     {
         device_source_impl::handle_decimation_interpolation(
-            samplerate, "voltage0", "sampling_frequency", dev, true);
+            samplerate, "voltage0", "sampling_frequency", dev, true, false);
     }
 
     device_source_impl::set_params(params);


### PR DESCRIPTION
Advanced filter configurations are now possible through the Pluto and
FMComms2 sink blocks. This includes filter designer controls and support
for the DEC8/INT8 filters now able in 2019-R2 releases from ADI. Pluto's
DEC8/INT8 filters have exists since very early firmware images.

This will also fix errors related to setting the sample rate like
"Unable to set out_voltage_sampling_frequency" since this update
properly sets the filters on sinks.

Signed-off-by: Travis F. Collins <travis.collins@analog.com>